### PR TITLE
Upgrade to GHC 9 (matching Granule) and LLVM 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ mkdir build && cd build
 # setup
 cmake -Wno-dev -G "Ninja" .. \
 -DCMAKE_BUILD_TYPE=Release \
--DCMAKE_CXX_FLAGS_RELEASE=-O0 \
 -DCMAKE_INSTALL_PREFIX=/usr/local/llvm-12 \
 -DLLVM_TARGETS_TO_BUILD="AArch64" \
 -DLLVM_INCLUDE_TOOLS=ON \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
 # granule-compiler-llvm
+
 LLVM compiler for Granule. This is a prototype which compiles on the functional core of Granule and does not yet support custom ADTs and GADTs.
 
 # Installation
 
-Installation requires the Granule front-end to be installed (see https://github.com/granule-project/granule).
-Then you can build this project via:
+Installation requires [Stack](https://docs.haskellstack.org/en/stable/README/) and LLVM 12.
 
-      stack install :grc
-   
-For general instructions on `stack` and the Granule build process, see the core repo.
+Build and install using Stack. The following will install the `grc` binary:
+
+```
+stack install :grc
+```
+
+## Installing LLVM 12
+
+LLVM 12 is available on Mac via Homebrew (until July 2025). It is available on _some_ Linux distributions via apt using the default repositories or through the [LLVM apt repository](https://apt.llvm.org/).
+
+```bash
+# mac
+brew install llvm@12
+
+# linux
+apt install llvm-12
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ LLVM compiler for Granule. This is a prototype which compiles on the functional 
 
 # Installation
 
-Installation requires [Stack](https://docs.haskellstack.org/en/stable/README/) and LLVM 12.
+Installation requires [Stack](https://docs.haskellstack.org/en/stable/README/) and [LLVM 12](https://releases.llvm.org/12.0.0/docs/index.html).
 
 Build and install using Stack. The following will install the `grc` binary:
 
@@ -14,12 +14,71 @@ stack install :grc
 
 ## Installing LLVM 12
 
-LLVM 12 is available on Mac via Homebrew (until July 2025). It is available on _some_ Linux distributions via apt using the default repositories or through the [LLVM apt repository](https://apt.llvm.org/).
+LLVM 12 is available on *some* macOS versions via Homebrew and *some* Linux distributions via their default apt repositories or the [LLVM apt repository](https://apt.llvm.org/).
 
 ```bash
 # mac
 brew install llvm@12
 
 # linux
-apt install llvm-12
+sudo apt install llvm-12
+```
+
+If you are not able to install through a package manager, or if you encounter any unexpected issues during building this project (especially `llvm-config` errors on macOS), which you are not able to resolve, you might need to build LLVM from source.
+
+## Building LLVM 12
+
+These are the steps I took to build LLVM 12 on an M1 MacBook running Sequoia 15.1. The process is very similar on Linux, minus the macOS specifics.
+
+
+1. Install build dependencies:
+```bash
+brew install cmake ninja
+```
+
+2. Get the source, create a build directory:
+```bash
+git clone https://github.com/llvm/llvm-project -b release/12.x --single-branch --depth 1
+cd llvm-project/llvm
+mkdir build && cd build
+```
+
+3. Build. Choose a sensible installation path. The dylib flags are necessary, the rest are for build speed:
+```
+# setup
+cmake -Wno-dev -G "Ninja" .. \
+-DCMAKE_BUILD_TYPE=Release \
+-DCMAKE_CXX_FLAGS_RELEASE=-O0 \
+-DCMAKE_INSTALL_PREFIX=/usr/local/llvm-12 \
+-DLLVM_TARGETS_TO_BUILD="AArch64" \
+-DLLVM_INCLUDE_TOOLS=ON \
+-DLLVM_INCLUDE_EXAMPLES=OFF \
+-DLLVM_INCLUDE_TESTS=OFF \
+-DLLVM_INCLUDE_BENCHMARKS=OFF \
+-DLLVM_ENABLE_BINDINGS=OFF \
+-DLLVM_BUILD_LLVM_DYLIB=ON \
+-DLLVM_LINK_LLVM_DYLIB=ON
+
+# build (take a break!)
+ninja
+
+# install
+sudo ninja install
+```
+
+4. Clean up and permissions. The `-12` suffix is sometimes expected on the dylib. The `install_name_tool` usage is for [SIP](https://support.apple.com/en-gb/102149):
+```
+cd /usr/local/llvm-12/lib
+sudo ln -s libLLVM.dylib libLLVM-12.dylib
+sudo install_name_tool -id $PWD/libLTO.dylib libLTO.dylib
+sudo install_name_tool -id $PWD/libLLVM.dylib libLLVM.dylib
+sudo install_name_tool -change '@rpath/libLLVM.dylib' $PWD/libLLVM.dylib libLTO.dylib
+
+```
+
+5. Add the following to your .zshrc or equivalent:
+
+```bash
+export PATH="/usr/local/llvm-12/bin:$PATH"
+export LD_LIBRARY_PATH="/usr/local/llvm-12/lib:$LD_LIBRARY_PATH"
 ```

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  stack:

--- a/src/Language/Granule/Codegen/Compile.hs
+++ b/src/Language/Granule/Codegen/Compile.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ImplicitParams #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 module Language.Granule.Codegen.Compile where
 
 import Language.Granule.Syntax.Def

--- a/src/Language/Granule/Codegen/Emit/EmitLLVM.hs
+++ b/src/Language/Granule/Codegen/Emit/EmitLLVM.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 module Language.Granule.Codegen.Emit.EmitLLVM where
 
 import qualified LLVM.AST as IR

--- a/src/Language/Granule/Codegen/Emit/LLVMHelpers.hs
+++ b/src/Language/Granule/Codegen/Emit/LLVMHelpers.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
 module Language.Granule.Codegen.Emit.LLVMHelpers where
 
 import Data.Traversable

--- a/src/Language/Granule/Codegen/Emit/LowerClosure.hs
+++ b/src/Language/Granule/Codegen/Emit/LowerClosure.hs
@@ -78,7 +78,7 @@ emitEnvironmentInit variableInitializers env maybeParentEnv =
                   value <- local ident
                   store uninitAddr 4 value
 
-emitClosureConstruction :: (MonadIRBuilder m)
+emitClosureConstruction :: (MonadIRBuilder m, MonadModuleBuilder m)
                         => Id
                         -> GrType
                         -> Operand
@@ -118,6 +118,6 @@ emitTrivialClosure (definitionIdentifier, definitionType) =
           closureType = llvmType definitionType
           initializer = makeTrivialClosure definitionIdentifier definitionType
 
-mallocEnvironment :: (MonadIRBuilder m) => IrType -> m Operand
+mallocEnvironment :: (MonadIRBuilder m, MonadModuleBuilder m) => IrType -> m Operand
 mallocEnvironment ty =
     call (ConstantOperand malloc) [(ConstantOperand $ sizeOf ty, [])]

--- a/src/Language/Granule/Codegen/Emit/LowerExpression.hs
+++ b/src/Language/Granule/Codegen/Emit/LowerExpression.hs
@@ -44,7 +44,7 @@ emitExpression :: (MonadState EmitterState m, MonadModuleBuilder m, MonadIRBuild
 emitExpression env =
     bipara (emitExpr env) (emitValue env)
 
-emitExpr :: (MonadState EmitterState m, MonadIRBuilder m, MonadFix m)
+emitExpr :: (MonadState EmitterState m, MonadModuleBuilder m, MonadIRBuilder m, MonadFix m)
          => Maybe Operand
          -> ExprF (Either GlobalMarker ClosureMarker) Type (EmitableExpr, m Operand) (EmitableValue, m Operand)
          -> m Operand

--- a/src/Language/Granule/Codegen/Emit/LowerOperator.hs
+++ b/src/Language/Granule/Codegen/Emit/LowerOperator.hs
@@ -7,10 +7,11 @@ import Language.Granule.Syntax.Expr (Operator(..))
 import LLVM.AST (Operand)
 import LLVM.IRBuilder.Instruction
 import LLVM.IRBuilder.Monad
+import LLVM.IRBuilder.Module (MonadModuleBuilder)
 import qualified LLVM.AST.IntegerPredicate as IP
 import qualified LLVM.AST.FloatingPointPredicate as FPP
 
-llvmOperator :: (MonadIRBuilder m)
+llvmOperator :: (MonadIRBuilder m, MonadModuleBuilder m)
              => GrType
              -> Operator
              -> GrType

--- a/src/Language/Granule/Codegen/Emit/Primitives.hs
+++ b/src/Language/Granule/Codegen/Emit/Primitives.hs
@@ -5,6 +5,7 @@ import LLVM.IRBuilder.Instruction
 import LLVM.AST (mkName, Operand(..))
 import LLVM.AST.Constant (Constant, Constant(..))
 import LLVM.AST.Type (i8, i32, i64, ptr, void, Type(..))
+import LLVM.IRBuilder (MonadModuleBuilder)
 
 malloc :: Constant
 malloc = GlobalReference functionType name
@@ -17,7 +18,7 @@ abort = GlobalReference functionType name
         where name = mkName "abort"
               functionType = ptr (FunctionType void [] False)
 
-trap :: (MonadIRBuilder m) => m ()
+trap :: (MonadIRBuilder m, MonadModuleBuilder m) => m ()
 trap = (call (ConstantOperand abort) []) >> unreachable >> return ()
 
 writeInt :: Constant

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,15 @@
-resolver: lts-18.28
+resolver: lts-20.26
 
 packages:
 - '.'
 
 extra-deps:
 - ConfigFile-1.1.4
-- llvm-hs-pure-9.0.0
-- llvm-hs-9.0.1
+- git: https://github.com/jacobpake/llvm-hs-12
+  commit: b684d4a1da9e017c98c6f4e67f08e3bd724473e9
+  subdirs:
+  - llvm-hs-pure
+  - llvm-hs
 - text-replace-0.1.0.3
 - sbv-9.0
 - syz-0.2.0.0@sha256:7307acb8f6ae7720e7e235c974281ecee912703c1394ebcac19caf83d70bb492,2345

--- a/tests/hspec/Language/Granule/Codegen/BuildAST.hs
+++ b/tests/hspec/Language/Granule/Codegen/BuildAST.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 module Language.Granule.Codegen.BuildAST where
 import Language.Granule.Codegen.NormalisedDef
 import Language.Granule.Codegen.MarkGlobals


### PR DESCRIPTION
Updates project to LLVM 12 and GHC 9.

LLVM itself is on version 19. The [llvm-hs bindings](https://github.com/llvm-hs/llvm-hs) are not actively maintained. They have branches for 12 and 15. I investigated 15 but this has significant API changes and would require many changes to the project, so this is left for later.

We use [a fork of llvm-hs-12](https://github.com/llvm-hs/llvm-hs/compare/llvm-12...jacobpake:llvm-hs-12:llvm-12) which updates bytestring so that there are no conflicts with GHC 9.2.8.

Add the LLVM installation requirement to the README with some notes on installing/building LLVM 12.