### PR TITLE
Rename executable, add QOL flags, usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ LLVM compiler for Granule. This is a prototype which compiles on the functional 
 
 Installation requires [Stack](https://docs.haskellstack.org/en/stable/README/) and [LLVM 12](https://releases.llvm.org/12.0.0/docs/index.html).
 
-Build and install using Stack. The following will install the `grc` binary:
+Build and install using Stack. The following will install the `grlc` binary:
 
 ```
-stack install :grc
+stack install
 ```
 
 ## Installing LLVM 12
 
-LLVM 12 is available on *some* macOS versions via Homebrew and *some* Linux distributions via their default apt repositories or the [LLVM apt repository](https://apt.llvm.org/).
+LLVM 12 is available on _some_ macOS versions via Homebrew and _some_ Linux distributions via their default apt repositories or the [LLVM apt repository](https://apt.llvm.org/).
 
 ```bash
 # mac
@@ -30,13 +30,14 @@ If you are not able to install through a package manager, or if you encounter an
 
 These are the steps I took to build LLVM 12 on an M1 MacBook running Sequoia 15.1. The process is very similar on Linux, minus the macOS specifics.
 
-
 1. Install build dependencies:
+
 ```bash
 brew install cmake ninja
 ```
 
 2. Get the source, create a build directory:
+
 ```bash
 git clone https://github.com/llvm/llvm-project -b release/12.x --single-branch --depth 1
 cd llvm-project/llvm
@@ -44,6 +45,7 @@ mkdir build && cd build
 ```
 
 3. Build. Choose a sensible installation path. The dylib flags are necessary, the rest are for build speed:
+
 ```
 # setup
 cmake -Wno-dev -G "Ninja" .. \
@@ -66,6 +68,7 @@ sudo ninja install
 ```
 
 4. Clean up and permissions. The `-12` suffix is sometimes expected on the dylib. The `install_name_tool` usage is for [SIP](https://support.apple.com/en-gb/102149):
+
 ```
 cd /usr/local/llvm-12/lib
 sudo ln -s libLLVM.dylib libLLVM-12.dylib

--- a/README.md
+++ b/README.md
@@ -2,21 +2,42 @@
 
 LLVM compiler for Granule. This is a prototype which compiles on the functional core of Granule and does not yet support custom ADTs and GADTs.
 
-# Installation
+## Installation
 
 Installation requires [Stack](https://docs.haskellstack.org/en/stable/README/) and [LLVM 12](https://releases.llvm.org/12.0.0/docs/index.html).
 
 Build and install using Stack. The following will install the `grlc` binary:
 
-```
+```sh
 stack install
+```
+
+## Running the compiler
+
+```sh
+# Build an executable
+grlc example.gr
+
+# Build an executable and run it, remove object (.o) files
+grlc example.gr --clean --run
+```
+
+### Flags
+
+```
+-c, --compile-only      # Stop after generating object (.o) files, do not create executable
+-o, --output NAME       # Specify executable name
+    --emit-llvm         # Generate LLVM bitcode (.bc) files
+    --emit-ir           # Generate LLVM IR (.ll) files
+    --clean             # Remove object (.o) files after successful linking
+    --run               # Run the executable
 ```
 
 ## Installing LLVM 12
 
 LLVM 12 is available on _some_ macOS versions via Homebrew and _some_ Linux distributions via their default apt repositories or the [LLVM apt repository](https://apt.llvm.org/).
 
-```bash
+```sh
 # mac
 brew install llvm@12
 
@@ -32,13 +53,13 @@ These are the steps I took to build LLVM 12 on an M1 MacBook running Sequoia 15.
 
 1. Install build dependencies:
 
-```bash
+```sh
 brew install cmake ninja
 ```
 
 2. Get the source, create a build directory:
 
-```bash
+```sh
 git clone https://github.com/llvm/llvm-project -b release/12.x --single-branch --depth 1
 cd llvm-project/llvm
 mkdir build && cd build
@@ -46,7 +67,7 @@ mkdir build && cd build
 
 3. Build. Choose a sensible installation path. The dylib flags are necessary, the rest are for build speed:
 
-```
+```sh
 # setup
 cmake -Wno-dev -G "Ninja" .. \
 -DCMAKE_BUILD_TYPE=Release \
@@ -69,7 +90,7 @@ sudo ninja install
 
 4. Clean up and permissions. The `-12` suffix is sometimes expected on the dylib. The `install_name_tool` usage is for [SIP](https://support.apple.com/en-gb/102149):
 
-```
+```sh
 cd /usr/local/llvm-12/lib
 sudo ln -s libLLVM.dylib libLLVM-12.dylib
 sudo install_name_tool -id $PWD/libLTO.dylib libLTO.dylib
@@ -80,7 +101,7 @@ sudo install_name_tool -change '@rpath/libLLVM.dylib' $PWD/libLLVM.dylib libLTO.
 
 5. Add the following to your .zshrc or equivalent:
 
-```bash
+```sh
 export PATH="/usr/local/llvm-12/bin:$PATH"
 export LD_LIBRARY_PATH="/usr/local/llvm-12/lib:$LD_LIBRARY_PATH"
 ```

--- a/granule-compiler.cabal
+++ b/granule-compiler.cabal
@@ -58,9 +58,10 @@ library
       base >=4.10 && <5
     , containers
     , granule-frontend
-    , llvm-hs >=6.0
-    , llvm-hs-pure >=6.0
+    , llvm-hs ==12.*
+    , llvm-hs-pure ==12.*
     , mtl
+    , process
     , text
   default-language: Haskell2010
 
@@ -86,9 +87,10 @@ executable grlc
     , gitrev
     , granule-compiler
     , granule-frontend
-    , llvm-hs >=6.0
-    , llvm-hs-pure >=6.0
+    , llvm-hs ==12.*
+    , llvm-hs-pure ==12.*
     , optparse-applicative
+    , process
     , text
   default-language: Haskell2010
 
@@ -119,6 +121,7 @@ test-suite compiler-spec
     , granule-frontend
     , hspec
     , mtl
+    , process
     , transformers >=0.5
   default-language: Haskell2010
 
@@ -142,8 +145,8 @@ test-suite golden
     , filepath
     , granule-compiler
     , granule-frontend
-    , llvm-hs >=6.0
-    , llvm-hs-pure >=6.0
+    , llvm-hs ==12.*
+    , llvm-hs-pure ==12.*
     , process
     , string-conversions
     , tasty

--- a/granule-compiler.cabal
+++ b/granule-compiler.cabal
@@ -64,7 +64,7 @@ library
     , text
   default-language: Haskell2010
 
-executable grc
+executable grlc
   main-is: Main.hs
   other-modules:
       Paths_granule_compiler

--- a/package.yaml
+++ b/package.yaml
@@ -1,64 +1,64 @@
 name: granule-compiler
-version: '0.9.5.0'
+version: "0.9.5.0"
 synopsis: The Granule compiler
 author: Ed Brown, Dominic Orchard, Vilem-Benjamin Liepelt, Harley Eades III, Preston Keel
 copyright: 2018-2024 authors
 license: BSD3
 github: granule-project/granule-compiler-llvm
 dependencies:
-- base >=4.10 && <5
+  - base >=4.10 && <5
 default-extensions:
-- LambdaCase
-- RecordWildCards
-- ImplicitParams
-- ScopedTypeVariables
-- OverloadedStrings
+  - LambdaCase
+  - RecordWildCards
+  - ImplicitParams
+  - ScopedTypeVariables
+  - OverloadedStrings
 
 ghc-options:
-- -O0
-- -Wall
-- -Werror
-- -Wcompat
-- -Wredundant-constraints
-- -Wno-unused-matches
-- -Wno-name-shadowing
-- -Wno-type-defaults
-- -fmax-pmcheck-models=10000000
+  - -O0
+  - -Wall
+  - -Werror
+  - -Wcompat
+  - -Wredundant-constraints
+  - -Wno-unused-matches
+  - -Wno-name-shadowing
+  - -Wno-type-defaults
+  - -fmax-pmcheck-models=10000000
 
 library:
   source-dirs: src
   exposed-modules:
-  - Language.Granule.Codegen.NormalisedDef
-  - Language.Granule.Codegen.TopsortDefinitions
-  - Language.Granule.Codegen.ClosureFreeDef
-  - Language.Granule.Codegen.ConvertClosures
-  - Language.Granule.Codegen.Emit.EmitLLVM
-  - Language.Granule.Codegen.Compile
-  - Language.Granule.Codegen.MarkGlobals
+    - Language.Granule.Codegen.NormalisedDef
+    - Language.Granule.Codegen.TopsortDefinitions
+    - Language.Granule.Codegen.ClosureFreeDef
+    - Language.Granule.Codegen.ConvertClosures
+    - Language.Granule.Codegen.Emit.EmitLLVM
+    - Language.Granule.Codegen.Compile
+    - Language.Granule.Codegen.MarkGlobals
   dependencies:
-  - granule-frontend
-  - mtl
-  - text
-  - containers
-  - llvm-hs-pure >= 6.0
-  - llvm-hs >= 6.0
+    - granule-frontend
+    - mtl
+    - text
+    - containers
+    - llvm-hs-pure >= 6.0
+    - llvm-hs >= 6.0
 
 executables:
-  grc:
+  grlc:
     main: Main.hs
     source-dirs: app
     dependencies:
-    - granule-frontend
-    - granule-compiler
-    - text
-    - llvm-hs-pure >= 6.0
-    - llvm-hs >= 6.0
-    - filepath
-    - directory
-    - gitrev
-    - extra
-    - Glob
-    - optparse-applicative
+      - granule-frontend
+      - granule-compiler
+      - text
+      - llvm-hs-pure >= 6.0
+      - llvm-hs >= 6.0
+      - filepath
+      - directory
+      - gitrev
+      - extra
+      - Glob
+      - optparse-applicative
 #    - llvm-hs-pretty
 
 tests:
@@ -67,26 +67,26 @@ tests:
     source-dirs: tests/hspec
     ghc-options: -fno-warn-partial-type-signatures
     dependencies:
-    - filemanip
-    - directory
-    - granule-frontend
-    - granule-compiler
-    - hspec
-    - QuickCheck
-    - mtl
-    - transformers >=0.5
+      - filemanip
+      - directory
+      - granule-frontend
+      - granule-compiler
+      - hspec
+      - QuickCheck
+      - mtl
+      - transformers >=0.5
   golden:
     main: Golden.hs
     source-dirs: tests/golden
     dependencies:
-    - granule-frontend
-    - granule-compiler
-    - llvm-hs-pure >= 6.0
-    - llvm-hs >= 6.0
-    - filepath
-    - process
-    - directory
-    - tasty
-    - tasty-golden
-    - string-conversions
-    - text
+      - granule-frontend
+      - granule-compiler
+      - llvm-hs-pure >= 6.0
+      - llvm-hs >= 6.0
+      - filepath
+      - process
+      - directory
+      - tasty
+      - tasty-golden
+      - string-conversions
+      - text

--- a/package.yaml
+++ b/package.yaml
@@ -7,6 +7,7 @@ license: BSD3
 github: granule-project/granule-compiler-llvm
 dependencies:
   - base >=4.10 && <5
+  - process
 default-extensions:
   - LambdaCase
   - RecordWildCards
@@ -40,8 +41,8 @@ library:
     - mtl
     - text
     - containers
-    - llvm-hs-pure >= 6.0
-    - llvm-hs >= 6.0
+    - llvm-hs-pure >= 12 && < 13
+    - llvm-hs >= 12 && < 13
 
 executables:
   grlc:
@@ -51,15 +52,14 @@ executables:
       - granule-frontend
       - granule-compiler
       - text
-      - llvm-hs-pure >= 6.0
-      - llvm-hs >= 6.0
+      - llvm-hs-pure >= 12 && < 13
+      - llvm-hs >= 12 && < 13
       - filepath
       - directory
       - gitrev
       - extra
       - Glob
       - optparse-applicative
-#    - llvm-hs-pretty
 
 tests:
   compiler-spec:
@@ -81,8 +81,8 @@ tests:
     dependencies:
       - granule-frontend
       - granule-compiler
-      - llvm-hs-pure >= 6.0
-      - llvm-hs >= 6.0
+      - llvm-hs-pure >= 12 && < 13
+      - llvm-hs >= 12 && < 13
       - filepath
       - process
       - directory


### PR DESCRIPTION
Renaming executable to `grlc` (Granule LLVM compiler) to avoid conflict with the `grc` Haskell compiler.

Adds some flags to the executable:

```
-c, --compile-only      # Stop after generating object (.o) files, do not create executable
-o, --output NAME       # Specify executable name
    --emit-llvm         # Generate LLVM bitcode (.bc) files
    --emit-ir           # Generate LLVM IR (.ll) files
    --clean             # Remove object (.o) files after successful linking
    --run               # Run the executable
```
